### PR TITLE
[ZETA-6904]: Add global variable for relative path to root

### DIFF
--- a/src/rz/global-variables/variable-dependencies/variable-dependencies.ts
+++ b/src/rz/global-variables/variable-dependencies/variable-dependencies.ts
@@ -188,4 +188,11 @@ export const powerUpVariablesFlatData: PowerUpVariables[] = [
       stubValue: 'infrastructureCommandPath',
       variableDependency: 'infrastructureCommandPath'
     },
+    {
+      name: 'relativePathFromRoot',
+      description: 'Will construct the relative path from root of project',
+      defaultValue: 'relativePathFromRoot',
+      stubValue: 'relativePathFromRoot',
+      variableDependency: 'relativePathFromRoot'
+    },
   ]

--- a/src/rz/global-variables/variables-to-ignore/variables-to-ignore.ts
+++ b/src/rz/global-variables/variables-to-ignore/variables-to-ignore.ts
@@ -152,5 +152,12 @@ export const powerUpVariables: PowerUpVariables[] = [
     defaultValue: 'infrastructureCommandPath',
     stubValue: 'infrastructureCommandPath',
     variableDependency: 'infrastructureCommandPath'
+  },
+  {
+    name: 'relativePathFromRoot',
+    description: 'Will construct the relative path from root of project',
+    defaultValue: 'relativePathFromRoot',
+    stubValue: 'relativePathFromRoot',
+    variableDependency: 'relativePathFromRoot'
   }
 ]


### PR DESCRIPTION
Notes: 

1. Adds a global variable that can be used to construct the relative path to a root dynamically. Will be useful in construction of libs 